### PR TITLE
Loosen requirements for python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setuptools.setup(
         "textnorm",
         "webiquette @ git+https://github.com/paregorios/webiquette.git",
     ],
-    python_requires=">=3",
+    python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setuptools.setup(
         "textnorm",
         "webiquette @ git+https://github.com/paregorios/webiquette.git",
     ],
-    python_requires="==3.10.2",
+    python_requires=">=3",
 )


### PR DESCRIPTION
The strict requirement of python 3.10.2 severely limits the usability of this package, e.g. when using in conjunction with other libraries with other requirements, or on older servers. As for the code itself, no features of python 3.10 are used and as such, requiring any python >= 3.6 has shown sufficient (I have been able to run this on an older ubuntu server).